### PR TITLE
:ambulance: Hotfix: ECS task definition 오류 수정 - enableFaultInjection 필드 제

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -86,6 +86,5 @@
   },
   "registeredAt": "2025-04-21T06:25:46.866Z",
   "registeredBy": "arn:aws:iam::885532410426:user/SangHoKim",
-  "enableFaultInjection": false,
   "tags": []
 }


### PR DESCRIPTION
## 🔧 변경 내용
- AWS ECS RegisterTaskDefinition API가 인식하지 못하는 `enableFaultInjection` 필드를 ecs-task-definition.json에서 제거하였습니다.
- 해당 필드는 콘솔에서는 보이지만, API에서는 허용되지 않기 때문에 자동 배포가 실패하고 있었습니다.

## ✅ 기대 효과
- GitHub Actions 배포가 정상적으로 진행됩니다.
- register-task-definition 호출이 성공적으로 완료됩니다.

---
