### PR TITLE
[#63] :ambulance: Hotfix:CI 빌드 시점에 환경변수 설정

### DIFF
--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -52,6 +52,9 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle Wrapper
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
         run: ./gradlew build --no-daemon
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).


### PR DESCRIPTION
### CI 빌드 환경 변수 추가
스프링부트 gradlew build 시점에 환경변수 값이 없어서 빌드 실패하는 문제점 해결

### 이슈
closes #59 