### PR TITLE
[#79] ✅ Test Notification 읽음 상태 변경 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/codeit/sb01_deokhugam/domain/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/domain/comment/entity/Comment.java
@@ -3,6 +3,7 @@ package com.codeit.sb01_deokhugam.domain.comment.entity;
 import java.util.UUID;
 
 import com.codeit.sb01_deokhugam.domain.base.BaseUpdatableEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -12,35 +13,35 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "comment")
+@Table(name = "comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseUpdatableEntity {
 
-    @Column(name = "review_id", nullable = false)
-    private UUID reviewId;
+	@Column(name = "review_id", nullable = false)
+	private UUID reviewId;
 
-    @Column(name = "user_id", nullable = false)
-    private UUID userId;
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
 
-    @Column(name = "content", nullable = false)
-    private String content;
+	@Column(name = "content", nullable = false)
+	private String content;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean deleted;
+	@Column(name = "is_deleted", nullable = false)
+	private boolean deleted;
 
-    public Comment(UUID reviewId, UUID userId, String content) {
-        this.reviewId = reviewId;
-        this.userId = userId;
-        this.content = content;
-        this.deleted = false;
-    }
+	public Comment(UUID reviewId, UUID userId, String content) {
+		this.reviewId = reviewId;
+		this.userId = userId;
+		this.content = content;
+		this.deleted = false;
+	}
 
-    public void updateContent(String content) {
-        this.content = content;
-    }
+	public void updateContent(String content) {
+		this.content = content;
+	}
 
-    public void markDeleted() {
-        this.deleted = true;
-    }
+	public void markDeleted() {
+		this.deleted = true;
+	}
 
 }

--- a/src/main/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepository.java
@@ -10,7 +10,7 @@ import com.codeit.sb01_deokhugam.domain.notification.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-	@Query(value = "SELECT n FROM Notification n WHERE n.id= :id AND n.user.id = :userId")
+	@Query(value = "SELECT n FROM Notification n join fetch n.user join fetch n.review WHERE n.id= :id AND n.user.id = :userId")
 	Optional<Notification> findByIdAndUserId(UUID id, UUID userId);
 
 }

--- a/src/main/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepository.java
@@ -5,12 +5,13 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.codeit.sb01_deokhugam.domain.notification.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-	@Query(value = "SELECT n FROM Notification n join fetch n.user join fetch n.review WHERE n.id= :id AND n.user.id = :userId")
-	Optional<Notification> findByIdAndUserId(UUID id, UUID userId);
+	@Query(value = "SELECT n FROM Notification n JOIN FETCH n.user u JOIN FETCH n.review r WHERE n.id = :id AND n.user.id = :userId")
+	Optional<Notification> findByIdAndUserId(@Param("id") UUID id, @Param("userId") UUID userId);
 
 }

--- a/src/main/java/com/codeit/sb01_deokhugam/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/domain/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.codeit.sb01_deokhugam.domain.notification.service;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.codeit.sb01_deokhugam.domain.notification.dto.response.NotificationDto;
 import com.codeit.sb01_deokhugam.domain.notification.entity.Notification;
@@ -18,6 +19,7 @@ public class NotificationService {
 
 	private final NotificationRepository notificationRepository;
 
+	@Transactional
 	public NotificationDto confirmNotification(UUID notificationId, UUID userId) {
 		Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
 			.orElseThrow(() -> new NotificationException(ErrorCode.NOTIFICATION_NOT_FOUND));

--- a/src/main/java/com/codeit/sb01_deokhugam/domain/review/entity/Review.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/domain/review/entity/Review.java
@@ -23,11 +23,11 @@ import lombok.NoArgsConstructor;
 public class Review extends BaseUpdatableEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "user_id", columnDefinition = "uuid NOT NULL")
+	@JoinColumn(name = "user_id", nullable = false)
 	private User author;
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "book_id", columnDefinition = "uuid NOT NULL")
+	@JoinColumn(name = "book_id", nullable = false)
 	private Book book;
 
 	@Column(name = "content", nullable = false)

--- a/src/main/java/com/codeit/sb01_deokhugam/domain/review/entity/Review.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/domain/review/entity/Review.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "review")
+@Table(name = "reviews")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseUpdatableEntity {
 

--- a/src/main/java/com/codeit/sb01_deokhugam/global/resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/codeit/sb01_deokhugam/global/resolver/LoginUserIdArgumentResolver.java
@@ -1,5 +1,7 @@
 package com.codeit.sb01_deokhugam.global.resolver;
 
+import java.util.UUID;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -27,6 +29,10 @@ public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolve
 		if (userId == null) {
 			throw new LoginRequiredException(ErrorCode.UNAUTHORIZED);
 		}
-		return userId;
+		try {
+			return UUID.fromString(userId);
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("잘못된 UUID 형식입니다: " + userId);
+		}
 	}
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,12 +1,12 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+  sql:
+    init:
+      mode: always       # 항상 schema.sql, data.sql 실행
+      schema-locations: classpath:schema.sql
+      data-locations: classpath:data.sql
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
       data-locations: classpath:data.sql
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,27 @@
+-- USERS
+INSERT INTO users (id, created_at, updated_at, email, nickname, password, is_deleted)
+VALUES ('54b78d8f-68fb-4c60-8f26-00bb1a5e219d', now(), now(),
+        'tester@example.com', '테스터', 'encoded-password', false);
+
+-- BOOKS
+INSERT INTO books (id, created_at, updated_at, title, author, description, publisher,
+                   published_date, isbn, thumbnail_url, review_count, rating, is_deleted)
+VALUES ('11111111-2222-3333-4444-555555555555', now(), now(),
+        '테스트 책 제목', '작가 이름', '이 책은 테스트용입니다.',
+        '출판사 이름', TIMESTAMP '2024-01-01 00:00:00',
+        '1234567890123', 'http://example.com/thumb.jpg', 0, 4.5, false);
+
+-- REVIEWS
+INSERT INTO reviews (id, created_at, updated_at, content, rating, like_count, comment_count,
+                     is_deleted, user_id, book_id)
+VALUES ('22222222-3333-4444-5555-666666666666', now(), now(),
+        '정말 좋은 리뷰입니다.', 4.5, 0, 0, false,
+        '54b78d8f-68fb-4c60-8f26-00bb1a5e219d',
+        '11111111-2222-3333-4444-555555555555');
+
+-- NOTIFICATIONS
+INSERT INTO notifications (id, created_at, updated_at, content, is_confirmed, user_id, review_id)
+VALUES ('cc1b6cbd-4b76-4204-9294-1bc918ffd1c8', now(), now(),
+        '[테스터]님이 좋아요를 눌렀습니다.', false,
+        '54b78d8f-68fb-4c60-8f26-00bb1a5e219d',
+        '22222222-3333-4444-5555-666666666666');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -55,7 +55,7 @@ create table books
     author         varchar                  NOT NULL,
     description    varchar                  NOT NULL,
     publisher      varchar                  NOT NULL,
-    published_date timestamp with time zone NOT NULL,
+    published_date date                     NOT NULL,
     isbn           varchar                  NOT NULL,
     thumbnail_url  varchar                  NOT NULL,
     review_count   integer                  NOT NULL default 0,

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/controller/NotificationControllerTest.java
@@ -21,8 +21,6 @@ import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -34,9 +32,6 @@ class NotificationControllerTest {
 
 	@LocalServerPort
 	int port;
-
-	@PersistenceContext
-	private EntityManager entityManager;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,86 @@
+package com.codeit.sb01_deokhugam.domain.notification.controller;
+
+import static io.restassured.RestAssured.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class NotificationControllerTest {
+
+	public static final String LOGIN_USER_HEADER = "Deokhugam-Request-User-ID";
+	public static final String USER_ID_UUID = "54b78d8f-68fb-4c60-8f26-00bb1a5e219d";
+	public static final String NOTIFICATION_ID_UUID = "cc1b6cbd-4b76-4204-9294-1bc918ffd1c8";
+
+	@LocalServerPort
+	int port;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@BeforeEach
+	void setUp() {
+		RestAssured.port = port;
+	}
+
+	@DisplayName("updateConfirm : 알림 확인 수정 API 테스트")
+	@Test
+	void update_notification_status_return_200() {
+		// given
+		Map<String, Object> requestBody = Map.of("confirmed", true);
+
+		given().log().all()
+			.header(LOGIN_USER_HEADER, USER_ID_UUID)
+			.contentType(ContentType.JSON)
+			.body(requestBody)
+			.when().patch("/api/notifications/{id}", NOTIFICATION_ID_UUID)
+			.then().log().all()
+			.statusCode(200)
+			.body("id", equalTo(NOTIFICATION_ID_UUID))
+			.body("confirmed", equalTo(true));
+	}
+
+	@DisplayName("updateConfirm : 알림 확인 수정 API 실패 테스트 - 존재하지 않는 알림 ID")
+	@Test
+	void testMethodNameHere() {
+		//given
+		UUID invalidNotificationId = UUID.randomUUID();
+		Map<String, Object> requestBody = Map.of("confirmed", true);
+		// when
+		ExtractableResponse<Response> response = given().log().all()
+			.header(LOGIN_USER_HEADER, USER_ID_UUID)
+			.contentType(ContentType.JSON)
+			.body(requestBody)
+			.when().patch("/api/notifications/{id}", invalidNotificationId)
+			.then().log().all()
+			.extract();
+		// then
+		final JsonPath result = response.jsonPath();
+		Assertions.assertAll(
+			() -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
+			() -> assertThat(result.getString("message")).isEqualTo("해당 알림이 존재하지 않습니다."),
+			() -> assertThat(result.getString("code")).isEqualTo("NOTIFICATION_NOT_FOUND"),
+			() -> assertThat(result.getString("timestamp")).isNotNull()
+		);
+	}
+}

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepositoryTest.java
@@ -75,7 +75,7 @@ class NotificationRepositoryTest {
 		entityManager.persist(notification);
 		entityManager.flush();
 		entityManager.clear();
-		
+
 		// when
 		Notification foundNotification = notificationRepository.findByIdAndUserId(notification.getId(), user.getId()).orElse(null);
 
@@ -87,7 +87,6 @@ class NotificationRepositoryTest {
 				assertThat(foundNotification.getReview().getId()).isEqualTo(review.getId());
 			}
 		);
-		assertThat(foundNotification).isNotNull();
 	}
 
 	@DisplayName("findByIdAndUserId: 알림 ID와 유저 ID 로 알림을 조회한다. 알림이 존재하지 않을 경우 빈 Optional 을 반환한다.")

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,8 @@
+package com.codeit.sb01_deokhugam.domain.notification.repository;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class NotificationRepositoryTest {
+
+}

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,8 +1,106 @@
 package com.codeit.sb01_deokhugam.domain.notification.repository;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.codeit.sb01_deokhugam.config.JpaAuditingConfiguration;
+import com.codeit.sb01_deokhugam.config.QueryDslConfig;
+import com.codeit.sb01_deokhugam.domain.book.entity.Book;
+import com.codeit.sb01_deokhugam.domain.notification.entity.Notification;
+import com.codeit.sb01_deokhugam.domain.review.entity.Review;
+import com.codeit.sb01_deokhugam.domain.user.entity.User;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 @DataJpaTest
+@ActiveProfiles("test")
+@Import({QueryDslConfig.class, JpaAuditingConfiguration.class})
 class NotificationRepositoryTest {
 
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private NotificationRepository notificationRepository;
+
+	private User user;
+	private Review review;
+
+	@BeforeEach
+	void setUp() {
+		user = new User("test@email.com", "password", "test");
+		Book book = getBook();
+		review = new Review(user, book, "좋은 책입니다.", new BigDecimal("4.5"));
+		entityManager.persist(user);
+		entityManager.persist(book);
+		entityManager.persist(review);
+		entityManager.flush();
+		entityManager.clear();
+	}
+
+	private static Book getBook() {
+		return new Book(
+			"이펙티브 자바",
+			"조슈아 블로크",
+			"자바 모범 사례를 담은 책입니다.",
+			"9780134685991",
+			"한빛미디어",
+			LocalDate.of(2018, 1, 1),
+			"https://example.com/thumbnail.jpg",
+			10,
+			new BigDecimal("4.8"),
+			false
+		);
+	}
+
+	@DisplayName("findByIdAndUserId: 알림 ID와 유저 ID 로 알림을 조회한다.")
+	@Test
+	void shouldReturnNotification_WhenExists() {
+		//given
+		Notification notification = Notification.fromComment(user, "좋은 책입니다.", review);
+		entityManager.persist(notification);
+		entityManager.flush();
+		entityManager.clear();
+		
+		// when
+		Notification foundNotification = notificationRepository.findByIdAndUserId(notification.getId(), user.getId()).orElse(null);
+
+		// then
+		assertAll(
+			() -> {
+				assertThat(foundNotification).isNotNull();
+				assertThat(foundNotification.getUser().getId()).isEqualTo(user.getId());
+				assertThat(foundNotification.getReview().getId()).isEqualTo(review.getId());
+			}
+		);
+		assertThat(foundNotification).isNotNull();
+	}
+
+	@DisplayName("findByIdAndUserId: 알림 ID와 유저 ID 로 알림을 조회한다. 알림이 존재하지 않을 경우 빈 Optional 을 반환한다.")
+	@Test
+	void findByIdAndUserId_ShouldReturnEmpty_WhenNotificationDoesNotExist() {
+		// given
+		UUID nonexistentNotificationId = UUID.randomUUID();
+		UUID nonexistentUserId = UUID.randomUUID();
+
+		// when
+		Optional<Notification> result = notificationRepository.findByIdAndUserId(nonexistentNotificationId, nonexistentUserId);
+
+		// then
+		assertThat(result).isEmpty();
+	}
 }

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,98 @@
+package com.codeit.sb01_deokhugam.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.codeit.sb01_deokhugam.domain.book.entity.Book;
+import com.codeit.sb01_deokhugam.domain.notification.dto.response.NotificationDto;
+import com.codeit.sb01_deokhugam.domain.notification.entity.Notification;
+import com.codeit.sb01_deokhugam.domain.notification.exception.NotificationException;
+import com.codeit.sb01_deokhugam.domain.notification.repository.NotificationRepository;
+import com.codeit.sb01_deokhugam.domain.review.entity.Review;
+import com.codeit.sb01_deokhugam.domain.user.entity.User;
+import com.codeit.sb01_deokhugam.global.exception.ErrorCode;
+import com.codeit.sb01_deokhugam.util.TestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+	@InjectMocks
+	private NotificationService notificationService;
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	private UUID notificationId;
+	private UUID userId;
+	private Notification notification;
+
+	@BeforeEach
+	void setUp() {
+		notificationId = UUID.randomUUID();
+		userId = UUID.randomUUID();
+
+		User user = new User("test@email.com", "pw", "닉네임");
+		Book book = getBook();
+		Review review = new Review(user, book, "좋아요", BigDecimal.valueOf(4.0));
+
+		notification = Notification.fromComment(user, "댓글 내용", review);
+		TestUtils.setId(notification, notificationId);
+	}
+
+	private static Book getBook() {
+		return new Book(
+			"이펙티브 자바",
+			"조슈아 블로크",
+			"자바 모범 사례를 담은 책입니다.",
+			"9780134685991",
+			"한빛미디어",
+			LocalDate.of(2018, 1, 1),
+			"https://example.com/thumbnail.jpg",
+			10,
+			new BigDecimal("4.8"),
+			false
+		);
+	}
+
+	@Test
+	@DisplayName("알림 확인 성공 시 DTO 반환")
+	void confirmNotification_Success() {
+		// given
+		given(notificationRepository.findByIdAndUserId(notificationId, userId))
+			.willReturn(Optional.of(notification));
+
+		// when
+		NotificationDto dto = notificationService.confirmNotification(notificationId, userId);
+
+		// then
+		assertThat(dto.id()).isEqualTo(notificationId);
+		assertThat(dto.confirmed()).isTrue();
+		verify(notificationRepository).findByIdAndUserId(notificationId, userId);
+	}
+
+	@DisplayName("알림이 없으면 예외 발생")
+	@Test
+	void confirmNotification_ThrowsException_WhenNotFound() {
+		//given
+		given(notificationRepository.findByIdAndUserId(notificationId, userId))
+			.willReturn(Optional.empty());
+
+		// when then
+		assertThatThrownBy(() -> notificationService.confirmNotification(notificationId, userId))
+			.isInstanceOf(NotificationException.class)
+			.hasMessageContaining(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage());
+		verify(notificationRepository).findByIdAndUserId(notificationId, userId);
+	}
+}

--- a/src/test/java/com/codeit/sb01_deokhugam/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/domain/notification/service/NotificationServiceTest.java
@@ -28,6 +28,7 @@ import com.codeit.sb01_deokhugam.util.TestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
+	
 	@InjectMocks
 	private NotificationService notificationService;
 

--- a/src/test/java/com/codeit/sb01_deokhugam/util/TestUtils.java
+++ b/src/test/java/com/codeit/sb01_deokhugam/util/TestUtils.java
@@ -1,0 +1,27 @@
+package com.codeit.sb01_deokhugam.util;
+
+import java.lang.reflect.Field;
+
+public class TestUtils {
+
+	public static void setField(Object target, String fieldName, Object value) {
+		Class<?> clazz = target.getClass();
+		while (clazz != null) {
+			try {
+				Field field = clazz.getDeclaredField(fieldName);
+				field.setAccessible(true);
+				field.set(target, value);
+				return;
+			} catch (NoSuchFieldException e) {
+				clazz = clazz.getSuperclass();
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("필드 접근 실패: " + fieldName, e);
+			}
+		}
+		throw new RuntimeException("필드를 찾을 수 없습니다: " + fieldName);
+	}
+
+	public static void setId(Object target, Object idValue) {
+		setField(target, "id", idValue);
+	}
+}


### PR DESCRIPTION
## 작업 내용
**Repository**
- NotificationRepository의 `findByIdAndUserId` 메서드에 대한 단위 테스트 추가
  - 정상적으로 알림과 유저 ID가 일치할 경우 알림 객체 반환
  - 존재하지 않는 알림 ID 또는 유저 ID를 조회할 경우 빈 Optional 반환

**Service**
- `NotificationService.confirmNotification()` 메서드 단위 테스트 작성
  - 알림 ID와 유저 ID로 조회 성공 시 읽음 처리 및 DTO 반환 확인
  - 존재하지 않는 알림인 경우 `NotificationException` 예외 검증
- `@Mock`과 `@InjectMocks`을 사용하여 Repository 의존성 분리 및 서비스 로직만 테스트

**Controller**
- NotificationController.updateConfirm() API에 대한 통합 테스트 추가
  - 정상적으로 알림 확인 처리 시 200 OK 응답 및 DTO 반환 검증
  - 존재하지 않는 알림 ID로 요청할 경우 404 Not Found 응답 및 에러 메시지 검증

RestAssured를 이용한 HTTP 요청/응답 기반 테스트 구성

### 테스트 유틸 클래스 분리
- 테스트 시 JPA `@Id` 필드를 강제로 세팅할 수 있도록 `TestUtils` 클래스 생성
  - 리플렉션 기반으로 상위 클래스까지 탐색하여 `id` 등 필드 주입
  - `TestUtils.setId(Object target, Object id)` 형태로 사용 가능
- 중복 코드 제거 및 추후 다른 도메인 테스트에서도 재사용 가능

## 테스트 구성
- `@DataJpaTest`를 활용하여 JPA 환경에서 테스트 수행
- `@BeforeEach`에서 테스트에 필요한 `User`, `Book`, `Review` 엔티티 사전 등록
- 통합 테스트에서 사용할 데이터를 미리 넣어두기 위해 data 스크립트 작성

## 이슈
closes #79  #75 #76 

## 기타
- 추후 fetch join query DSL 적용 고려
