### PR TITLE
[#106] Jacoco 테스트 커버리지 설정 

### DIFF
--- a/.github/workflows/ci-action.yml
+++ b/.github/workflows/ci-action.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write # jacoco PR 코멘트 작성 권한 추가
 
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +58,21 @@ jobs:
           AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
           SPRING_PROFILES_ACTIVE: ${{ secrets.SPRING_PROFILES_ACTIVE }}
         run: ./gradlew build --no-daemon
+
+      # Jacoco 설정
+      # ✅ 커버리지 리포트 생성
+      - name: Generate Jacoco Report
+        run: ./gradlew jacocoTestReport
+
+      # ✅  PR에 커버리지 코멘트 작성
+      - name: Comment test coverage on PR
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: 📝 테스트 커버리지 리포트
+          paths: ${{ github.workspace }}/build/jacocoReport/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 80
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.codeit'
@@ -12,6 +13,11 @@ java {
         languageVersion = JavaLanguageVersion.of(17)
     }
 
+}
+
+jacoco {
+    toolVersion = "0.8.10"
+    reportsDirectory = layout.buildDirectory.dir('jacocoReport')
 }
 
 bootJar {
@@ -66,10 +72,34 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport //테스트가 끝나고 Jacoco 리포트 작성
 }
 
+//jacoco 리포트 설정
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        xml.required = true
+        html.required = true
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            //분석 리포트에서 제외할 클래스를 설정합니다.
+                            '**/Q*.class',                        // QueryDSL Q클래스
+                            '**/generated/**',                   // generated 패키지 제외
+                            '**/mapper',              // 모든 mapper 패키지 제외
+                    ])
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
 
 //하위 queryDSL 관련 설정
 def querydslDir = "build/generated/querydsl" //Q클래스 생성 위치


### PR DESCRIPTION
# 변경사항
## Jacoco 도입
요구사항인 테스트 커버리지 80%이상 확인을 위해 jacoco를 도입했습니다
* build.gradle 의존성 추가
* ci-action 파일 수정
* 자동 생성되는 mapper, queryDsl의 Qclass 관련은 커버리지에서 제외했습니다 
* 저희가 TDD에서 BDD로 변경한만큼, 이미 비즈니스 로직이 많이 작성되어서 전체 테스트 커버리지를 한번에 요구사항인 80%이상으로 유지하는 것은 어려울듯합니다. (현재 19%정도 나옵니다. )
따라서 우선적으로 작성하여 **PR에 올리는 코드만을 커버리지 80%이상**으로 유지하고 올리고, 추후 전체 테스트 커버리지를 점진적으로 관리하면 좋을 것 같습니다. 
* ci-action의 커버리지 비율 통과 조건
   * 작성한 코드: 80%
   * 전체 코드: 0%



## Jacoco 테스트 커버리지 사용법
### 1. 로컬에서 확인하기

build이후 
CodeitSprint\sb01-deokhugam-team09\build\jacocoReport\test\html
경로에 생성되는 index.html 파일을 열면 전체 코드의 테스트 커버리지를 확인할 수 있어요 

![image](https://github.com/user-attachments/assets/f8e73ed3-fffd-4539-bf3f-d391959ac564)


![image](https://github.com/user-attachments/assets/e067f33d-2bee-4b76-9971-68578846b801)
클래스의 메서드 명을 클릭하면 어떤 코드가 커버되지 않았는지 상세히 확인이 가능합니다. 

![image](https://github.com/user-attachments/assets/35bb908c-5483-4f8f-9c41-048002f59ae0)


빨강: 🔴커버하지 못한 부분
노랑: 🟡커버되었으나 100% 커버하지 못한 부분
초록: 🟢완벽하게 커버된 부분


### 2. Github Actions에서
github actions에 Jacoco테스트 커버리지 체크 작업을 새롭게 정의했습니다. 
PR을 올리면 포함된 코드에 대하여 커버리지 체크 결과가 코멘트로 달리게 됩니다
제건데 통과하려면 열심히 올려야겠네요 🥹

![image](https://github.com/user-attachments/assets/12617e17-af17-4c5a-9b08-78572c9b3c17)


